### PR TITLE
Fix tests, add code coverage reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,17 @@
-apply plugin: 'maven'
+buildscript {
+	repositories {
+		jcenter()
+		
+		dependencies {
+			classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.2')
+			classpath(group: 'net.saliman', name: 'gradle-cobertura-plugin', version: '2.2.8')
+		}
+	}
+}
 apply plugin: 'groovy'
+apply plugin: 'maven'
+apply plugin: 'cobertura'
+apply plugin: 'jacoco'
 group = 'com.sysgears.example'
 version = '1.0'
 
@@ -12,7 +24,7 @@ sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 dependencies {
@@ -21,6 +33,7 @@ dependencies {
      compile "org.springframework:spring-context:${springVersion}"
      compile "org.springframework:spring-core:${springVersion}"
      compile "org.springframework:spring-expression:${springVersion}"
+	compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.+'
 
      // JSR 330 annotation support
      compile "javax.inject:javax.inject:1"
@@ -36,8 +49,37 @@ dependencies {
          exclude module: 'groovy-all'
      }
 
+	// optional dependencies for using Spock
+	// only necessary if Hamcrest matchers are used
+	testCompile 'org.hamcrest:hamcrest-core:1.3'
+	// allows mocking of classes (in addition to interfaces)
+	testRuntime 'cglib:cglib-nodep:3.2.0'
+	// allows mocking of classes without default constructor (together with CGLIB)
+	testRuntime 'org.objenesis:objenesis:2.2'
      // Groovy
      compile 'org.codehaus.groovy:groovy-all:2.4.4'
+}
+test {
+	reports.html.enabled = true
+	// show standard out and standard error of the test JVM(s) on the console
+	testLogging.showStandardStreams = true
+
+	// set heap size for the test JVM(s)
+	minHeapSize = '128m'
+	maxHeapSize = '512m'
+
+	// set JVM arguments for the test JVM(s)
+	jvmArgs '-XX:MaxPermSize=256m'
+
+	// listen to events in the test execution lifecycle
+	beforeTest { descriptor ->
+		logger.lifecycle('Running test: ' + descriptor)
+	}
+
+	// listen to standard out and standard error of the test JVM(s)
+	onOutput { descriptor, event ->
+		logger.lifecycle('Test: ' + descriptor + ' produced standard out/err: ' + event.message)
+	}
 }
 
 // Creates executable standalone JAR file of the application
@@ -57,6 +99,43 @@ task uberJar(type: Jar, dependsOn:[':compileJava',':compileGroovy']) {
                 'Built-JDK': System.getProperty('java.version'),
                 'Main-Class': mainClassName
     }
-
+}
+jacocoTestReport {
+	additionalSourceDirs = files(sourceSets.main.allSource.srcDirs)
+	sourceDirectories = files(sourceSets.main.allSource.srcDirs)
+	classDirectories = files(sourceSets.main.output)
+	executionData = files(jacocoTestReport.executionData)
+	reports {
+		html.enabled = true
+		xml.enabled = true
+		csv.enabled = false
+	}
 }
 
+//http://jdpgrailsdev.github.io/blog/2014/04/29/gradle_cobertura.html
+//https://github.com/stevesaliman/gradle-cobertura-plugin/blob/master/usage.md
+
+cobertura {
+	//fix cobertura version
+	//https://github.com/stevesaliman/gradle-cobertura-plugin/issues/72
+	//coberturaVersion = '2.1.1'
+	//coberturaVersion = '2.0.3'
+	coverageFormats = ['html', 'xml']
+	coverageIgnoreTrivial = true
+	coverageIgnores = ['org.slf4j.Logger.*']
+	coverageExcludes = ['.*package-info.*', 'net\\.gleske\\.jervis\\.exceptions\\..*']
+
+	//coberturaCheck values 80% (./gradlew coberturaCheck test)
+	//coverageCheckBranchRate = 80
+	//coverageCheckLineRate = 80
+	coverageCheckPackageBranchRate = 50
+	coverageCheckPackageLineRate = 80
+	coverageCheckTotalBranchRate = 50
+	coverageCheckTotalLineRate = 80
+	coverageCheckHaltOnFailure = true
+
+}
+test.finalizedBy(project.tasks.cobertura)
+task printBuildScriptClasspath << {
+	println project.buildscript.configurations.classpath.asPath
+}

--- a/src/test/groovy/com/sysgears/example/GreeterSpec.groovy
+++ b/src/test/groovy/com/sysgears/example/GreeterSpec.groovy
@@ -1,16 +1,21 @@
 package com.sysgears.example
 
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestExecutionListeners
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener
 import spock.lang.Specification
 
 import javax.inject.Inject
 
+@TestExecutionListeners(inheritListeners = false, listeners = [DependencyInjectionTestExecutionListener.class])
 @ContextConfiguration(classes = AppConfig.class)
 class GreeterSpec extends Specification {
-    private @Inject Greeter greeter
-    
+	private @Inject
+	Greeter greeter
+
     def 'check greeting'() {
         expect: 'should generate correct greet string'
-        greeter.greet('Hello', 'Test') == 'Hello, Test! (from greeter 1)' 
+        greeter.greet('Hello', 'Test') == 'Hello, Test! (from greeter 1)'
     }
 }

--- a/src/test/groovy/com/sysgears/example/MultiGreeterSpec.groovy
+++ b/src/test/groovy/com/sysgears/example/MultiGreeterSpec.groovy
@@ -4,13 +4,18 @@ import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.core.env.MapPropertySource
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestExecutionListeners
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener
 import spock.lang.Specification
 
 import javax.inject.Inject
 
 @ContextConfiguration(classes = AppConfig.class, initializers = TestContextInitializer.class)
+@TestExecutionListeners(inheritListeners = false, listeners = [DependencyInjectionTestExecutionListener.class])
 class MultiGreeterSpec extends Specification {
-    private @Inject MultiGreeter multiGreeter
+	private @Inject
+	MultiGreeter multiGreeter
 
     public static class TestContextInitializer implements
             ApplicationContextInitializer<ConfigurableApplicationContext> {


### PR DESCRIPTION
- Fix tests by excluding ServletTestExecutionListener, DirtiesContextTestExecutionListener, TransactionalTestExecutionListener, SqlScriptsTestExecutionListener from TestExecutionListeners\
- Add jacoco and cobertura test coverage, nicer test console output, html reports

Spring4 Test framework can't instantiate some of the default test listeners since they aren't on the classpath.  ServletTestExecutionListener and TransactionalTestExecutionListener in particular cause problems. The other ones I excluded aren't harmful, but aren't needed.

I used your example as the basis of my project, so I thought I'd backport my fixes to your example. Thanks for helping me out by having shared this project.
